### PR TITLE
feat(heapsnapshot): added heap snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ thetool -o . -t memoryallocation npm run test
 
 To analyze: open Chrome DevTools, go to Memory tab, click load button, select file with data.
 
+### Heap Snapshot tool
+
+```bash
+thetool -o . -t heapsnapshot node -e "captureTheTool.then(captureTheTool).then(captureTheTool)"
+```
+
+Given command will capture three heap snapshots.
+To analyze: open Chrome DevTools, go to Memory tab, click load button, select file with data. You can load multiple snapshots and compare them from DevTools UI.
+
 ### Tracing
 ```bash
 thetool -o . -t tracing --recordMode recordAsMuchAsPossible --includedCategories node,v8 npm run test

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ async function main(argv) {
   }
   if (nodeCommandLine.length < 1)
     return outputHelp('Error: please specify how to start node process');
-  const supportedProfiles = new Set(['cpu', 'memorysampling', 'memoryallocation', 'coverage', 'type', 'tracing']);
+  const supportedProfiles = new Set(['cpu', 'memorysampling', 'memoryallocation', 'coverage', 'type', 'tracing', 'heapsnapshot']);
   if (!supportedProfiles.has(toolName))
     return outputHelp('Error: please specify supported tool type using -t option');
   const code = checkOutputFolder(outputFolder);

--- a/lib/Runner.js
+++ b/lib/Runner.js
@@ -52,6 +52,11 @@ class ToolWrapper {
       return promise;
     }
   }
+
+  capture() {
+    const reportWrapper = new ReportWrapper(++ToolWrapper._lastId, this._callback);
+    return this._tool.capture(reportWrapper);
+  }
 }
 
 ToolWrapper._lastId = 0;
@@ -90,6 +95,7 @@ async function setupOnDemand(connection, wrapper) {
     }
     this.startTheTool = sendCommand.bind(null, 'thetool:start');
     this.stopTheTool = sendCommand.bind(null, 'thetool:stop');
+    this.captureTheTool = sendCommand.bind(null, 'thetool:capture');
   }
 
   await connection.send('Runtime.evaluate', {
@@ -105,6 +111,8 @@ async function setupOnDemand(connection, wrapper) {
       await wrapper.start();
     else if (arg0 === 'thetool:stop')
       await wrapper.stop();
+    else if (arg0 === 'thetool:capture')
+      await wrapper.capture();
     else
       return;
     await connection.send('Runtime.callFunctionOn', {

--- a/lib/Tool.js
+++ b/lib/Tool.js
@@ -23,6 +23,10 @@ class MemorySamplingProfiler {
     reporter.reportFinish();
   }
 
+  async capture(reporter) {
+    console.error('Heap sampling profiler supports only startTheTool/stopTheTool');
+  }
+
   onlyMain() {
     return false;
   }
@@ -48,6 +52,10 @@ class MemoryAllocationProfiler {
     reporter.reportFinish();
   }
 
+  async capture(reporter) {
+    console.error('Heap allocation profiler supports only startTheTool/stopTheTool');
+  }
+
   onlyMain() {
     return false;
   }
@@ -69,6 +77,10 @@ class CoverageProfiler {
     await this._connection.send('Profiler.stopPreciseCoverage');
     reporter.reportChunk(JSON.stringify(data));
     reporter.reportFinish();
+  }
+
+  async capture(reporter) {
+    console.error('Coverage profiler supports only startTheTool/stopTheTool');
   }
 
   onlyMain() {
@@ -93,6 +105,10 @@ class CPUProfiler {
     reporter.reportFinish();
   }
 
+  async capture(reporter) {
+    console.error('CPU profiler supports only startTheTool/stopTheTool');
+  }
+
   onlyMain() {
     return false;
   }
@@ -114,6 +130,10 @@ class TypeProfiler {
     await this._connection.send('Profiler.stopTypeProfile');
     reporter.reportChunk(JSON.stringify(data));
     reporter.reportFinish();
+  }
+
+  async capture(reporter) {
+    console.error('Type profiler supports only startTheTool/stopTheTool');
   }
 
   onlyMain() {
@@ -168,8 +188,38 @@ class Tracing {
     }
   }
 
+  async capture(reporter) {
+    console.error('Tracing supports only startTheTool/stopTheTool');
+  }
+
   onlyMain() {
     return true;
+  }
+}
+
+class HeapSnapshotTool {
+  constructor(connection) {
+    this._connection = connection;
+  }
+
+  async before(reporter) {
+    console.error('Heap snapshot supports only captureTheTool');
+  }
+
+  async after(reporter) {
+    console.error('Heap snapshot supports only captureTheTool');
+  }
+
+  async capture(reporter) {
+    reporter.reportStart('heapsnapshot', 'You can use Chrome DevTools Memory tab to load and analyze it.');
+    this._connection.on('HeapProfiler.addHeapSnapshotChunk', reportChunk);
+    await this._connection.send('HeapProfiler.takeHeapSnapshot');
+    this._connection.removeListener('HeapProfiler.addHeapSnapshotChunk', reportChunk);
+    reporter.reportFinish();
+
+    function reportChunk(value) {
+      reporter.reportChunk(value.chunk);
+    }
   }
 }
 
@@ -178,6 +228,8 @@ function createTool(name, toolOptions, connection) {
     return new MemorySamplingProfiler(connection, toolOptions);
   if (name === 'memoryallocation')
     return new MemoryAllocationProfiler(connection, toolOptions);
+  if (name === 'heapsnapshot')
+    return new HeapSnapshotTool(connection, toolOptions);
   if (name === 'coverage')
     return new CoverageProfiler(connection, toolOptions);
   if (name === 'cpu')


### PR DESCRIPTION
User can start tool with -t heapsnapshot -o . --ondemand flags and
calls captureTheTool() method from their scripts to capture current
heap snapshot.